### PR TITLE
Improving usage of cached and stored data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Angezeigte Informationen:
 Die Konfiguration erfolgt über die Date **config.json** im Ordner `iCloud/Scriptable/corona_widget_ts/`. Dort können,
 falls nicht anders vermerkt, folgende Werte gesetzt werden.
 
+# cache
+
+## cache.maxAge
+
+**Beschreibung**: Maximales Alter von gespeicherten Daten, damit diese als 'noch aktuell' angesehen werden und die Daten nicht erneut vom RKI geladen werden.\
+**Werte**: `(0, ∞)` (Sekunden) \
+**Standard**: `3600` (1h)
+
 ## graph
 
 Konfiguration für die angezeigten Graphen.

--- a/config.json
+++ b/config.json
@@ -1,4 +1,7 @@
 {
+  "cache": {
+    "maxAge": 3600
+  },
   "graph": {
     "maxShownDays": 28,
     "upsideDown": false,


### PR DESCRIPTION
Fixes an issue when multiple widgets being in use and creating unnecessary request to the api.
Widgets will use stored data that's fresh enough instead of requesting the data from the api.
The time frame is set by `CFG.cache.maxAge`.
maxAge <= 0: disabled
maxAge > 1: seconds stored data can be reused after storing it.